### PR TITLE
Nameless 1.0.21 update. Fixed some terrible bugs!

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ $ docker build -t namelessmc .
 If you want to specify the version:
 
 ```bash
-$ docker build --build-arg NAMELESSMC_VERSION=1.0.16 -t namelessmc .
+$ docker build --build-arg NAMELESSMC_VERSION=1.0.21 -t namelessmc .
 ```
 
 The version number **MUST BE** listed [here](https://github.com/NamelessMC/Nameless/releases) and it's **not guranteed** to work.
@@ -68,7 +68,7 @@ After deploying the containers, open up the corresponding URL in your web browse
 
 By default, the web server will be available at `0.0.0.0:80`, means if you deployed it on you own computer, the URL is gonna be `http://localhost`. Instead, if you did it on a remote server, the URL would be `http://<your-server-ip-addr>`.
 
-Follow the install instructions. When the database configuration page shows up, fill in `nameless_db` for the *database address*. For database username, password and database name, fill `nameless` for all of them, if you used default database credentials.
+Follow the install instructions. When the database configuration page shows up, fill in `db` for the *database address*. For database username, password and database name, fill `nameless` for all of them, if you used default database credentials.
 
 When you're done, submit and follow the rest of installation.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,13 +1,23 @@
-nameless:
-  build: src
-  links:
-    - db
-  ports:
-    - "80:80"
-db:
-  image: mysql
-  environment:
-    MYSQL_ROOT_PASSWORD: nameless
-    MYSQL_USER: nameless
-    MYSQL_PASSWORD: nameless
-    MYSQL_DATABASE: nameless
+version: '3.1'
+
+services:
+
+  nameless:
+    build:
+      context: src
+    restart: unless-stopped
+    links:
+      - db
+    ports:
+      - "80:80"
+
+  db:
+    image: mysql:5.7
+    restart: unless-stopped
+    expose:
+      - 3306
+    environment:
+      - "MYSQL_ROOT_PASSWORD=nameless"
+      - "MYSQL_USER=nameless"
+      - "MYSQL_PASSWORD=nameless"
+      - "MYSQL_DATABASE=nameless"

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -1,25 +1,27 @@
 FROM php:7.0-apache
 
-ARG NAMELESSMC_VERSION=1.0.16
+ARG NAMELESSMC_VERSION=1.0.21
 
 WORKDIR /var/www
 
 RUN docker-php-source extract \
     && apt-get update \
-    && apt-get install libmcrypt-dev libldap2-dev nano libpng12-dev libjpeg62-turbo-dev libfreetype6-dev curl tar -y \
+    && apt-get install -y libmcrypt-dev libldap2-dev libpng-dev libjpeg62-turbo-dev libfreetype6-dev curl tar \
     && docker-php-ext-install pdo pdo_mysql mysqli \
     && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
     && docker-php-ext-install -j$(nproc) gd mcrypt \
     && a2enmod rewrite \
-    && docker-php-source delete \
-    && curl -Lo nameless.tar.gz https://github.com/NamelessMC/Nameless/archive/v$NAMELESSMC_VERSION.tar.gz \
+    && docker-php-source delete
+
+RUN curl -Lo nameless.tar.gz https://github.com/NamelessMC/Nameless/archive/v$NAMELESSMC_VERSION.tar.gz \
     && tar -xvf nameless.tar.gz \
     && mv Nameless-$NAMELESSMC_VERSION/* /var/www/html/ \
     && bash -c "mv Nameless-$NAMELESSMC_VERSION/.[^.]* /var/www/html/" \
     && rm -rf nameless.tar.gz Nameless-$NAMELESSMC_VERSION \ 
     && chown -R www-data:www-data /var/www/html \
-    && chmod 755 -R /var/www/html \
-    && apt-get clean \ 
+    && chmod 755 -R /var/www/html
+
+RUN apt-get clean \ 
     && apt-get autoclean \ 
     && apt-get autoremove --purge -y \ 
     && rm -rf /var/lib/{apt,dpkg,cache,log}/ /tmp/* /var/tmp/*

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -9,7 +9,7 @@ RUN docker-php-source extract \
     && apt-get install -y libmcrypt-dev libldap2-dev libpng-dev libjpeg62-turbo-dev libfreetype6-dev curl tar \
     && docker-php-ext-install pdo pdo_mysql mysqli \
     && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
-    && docker-php-ext-install -j$(nproc) gd mcrypt \
+    && docker-php-ext-install -j$(nproc) gd \
     && a2enmod rewrite \
     && docker-php-source delete
 


### PR DESCRIPTION
Removed nano from the image
docker-compose re-structure to improve layer caching
Explicitly use mysql:5.7 for backend db

Edit: the commit message should be 1.0.21 update instead of 1.0.16. Sorry!